### PR TITLE
Fix use item animation

### DIFF
--- a/MicrowaveGame/Assets/Resources/Animations/Inventory/InventorySlotAnimationController.controller
+++ b/MicrowaveGame/Assets/Resources/Animations/Inventory/InventorySlotAnimationController.controller
@@ -80,8 +80,7 @@ AnimatorState:
   m_Name: InventorySlotUseItem
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 977234929240352244}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -221,28 +220,6 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
---- !u!1101 &977234929240352244
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -5462123184599303405}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.25
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1107 &1397553174935129128
 AnimatorStateMachine:
   serializedVersion: 6

--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
@@ -57,7 +57,7 @@ namespace Scripts.Inventory
 			if (ItemBehaviour != null)
 			{
 				bool canUse = ItemBehaviour.OnUseItem(this);
-				if (canUse) _animator.Play("InventorySlotUseItem");
+				_animator.Play(canUse ? "InventorySlotUseItem" : "InventorySlotIdle");
 			}
 		}
 


### PR DESCRIPTION
The PR #53 added item animations, however it didn't account for the use item animation being a continuous looping animation. This PR fixes that.

To test, drag the player, item speed increase, and level prefabs into the root scene, and drag the inventory prefab onto the main camera. When you pick up and use the item, it should pulsate until the item has completed its use time. It should then play the drop item animation.