### PR TITLE
Only allow nearby items to be added when colliding with the player

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Items/ItemBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Items/ItemBehaviour.cs
@@ -49,7 +49,14 @@ namespace Scripts.Items
 			_inventoryBehaviour = GameObject.Find("Inventory").GetComponent<InventoryBehaviour>();
 		}
 
-		private void OnTriggerEnter2D(Collider2D other) => _inventoryBehaviour.AddNearbyItem(this);
-		private void OnTriggerExit2D(Collider2D other) => _inventoryBehaviour.RemoveNearbyItem(this);
+		private void OnTriggerEnter2D(Collider2D other)
+		{
+			if (other.gameObject.name == "Player") _inventoryBehaviour.AddNearbyItem(this);
+		}
+
+		private void OnTriggerExit2D(Collider2D other)
+		{
+			if (other.gameObject.name == "Player") _inventoryBehaviour.RemoveNearbyItem(this);
+		}
 	}
 }


### PR DESCRIPTION
Currently, any object that collides with an item will add it to the nearby item list. This PR changes this so only when the player is colliding with an item should it be added to the nearby item list.