### PR TITLE
Ensure hazard collision is only done with the player

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardOilSpillBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardOilSpillBehaviour.cs
@@ -47,7 +47,8 @@ namespace Scripts.Hazards
 
 		private void OnTriggerStay2D(Collider2D other)
 		{
-			if (other.gameObject.name == "Player") _time = 0;
+			if (other.gameObject.name != "Player") return;
+			_time = 0;
 
 			if (!_applied)
 			{

--- a/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardSpikeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardSpikeBehaviour.cs
@@ -54,6 +54,7 @@ namespace Scripts.Hazards
 
 		private void OnTriggerEnter2D(Collider2D other)
 		{
+			if (other.gameObject.name != "Player") return;
 			_colliding = true;
 
 			_playerMovementBehaviour.MaxVelocity *= SlowdownFactor;
@@ -62,6 +63,8 @@ namespace Scripts.Hazards
 
 		private void OnTriggerExit2D(Collider2D other)
 		{
+			if (other.gameObject.name != "Player") return;
+
 			_colliding = false;
 			_playerMovementBehaviour.MaxVelocity /= SlowdownFactor;
 		}


### PR DESCRIPTION
This PR ensures hazard collision is only done with the player.
To test, place hazards in the scene and ensure they all work correctly.