### PR TITLE
Spawn an item when all enemies in the room have been defeated

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomBase.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomBase.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7422583930939099857}
   - component: {fileID: 1186674725662928174}
   - component: {fileID: 4032188139413544}
+  - component: {fileID: 5006194943048804317}
   m_Layer: 0
   m_Name: RoomBase
   m_TagString: Untagged
@@ -55,5 +56,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 16ad5562eefc4c548aa08373515f8caf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5006194943048804317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2160616897188144416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebb23afa31154580803714654fe046ed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomClearBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomClearBehaviour.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Scripts.Events;
+using Scripts.Items;
+using Scripts.Utilities;
+using UnityEngine;
+
+namespace Scripts.Rooms
+{
+	public class RoomClearBehaviour : MonoBehaviour
+	{
+		private EventId<HealthChangedEventArgs> _healthChangedEventId;
+		private int _enemyCount;
+
+		private static IEnumerable<GameObject> _itemPrefabs;
+
+		private void Start()
+		{
+			_itemPrefabs ??= Resources.LoadAll<GameObject>("Prefabs/Items")
+				.Where(itemPrefab => itemPrefab.HasComponent<ItemBehaviour>());
+
+			foreach (Transform childTransform in transform)
+			{
+				TagBehaviour tagBehaviour = childTransform.GetComponent<TagBehaviour>();
+				if (tagBehaviour != null && tagBehaviour.HasTag("Enemy")) _enemyCount++;
+			}
+
+			_healthChangedEventId = EventManager.Register<HealthChangedEventArgs>(OnHealthChanged);
+		}
+
+		private void OnHealthChanged(HealthChangedEventArgs eventArgs)
+		{
+			if (eventArgs.NewValue > 0) return;
+
+			TagBehaviour tagBehaviour = eventArgs.GameObject.GetComponent<TagBehaviour>();
+			if (tagBehaviour == null || !tagBehaviour.HasTag("Enemy")) return;
+
+			_enemyCount--;
+			if (_enemyCount != 0) return;
+
+			GameObject randomItemPrefab = _itemPrefabs.GetRandomElement();
+			Instantiate(randomItemPrefab, transform);
+
+			EventManager.Unregister(_healthChangedEventId);
+		}
+	}
+}

--- a/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomClearBehaviour.cs.meta
+++ b/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomClearBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebb23afa31154580803714654fe046ed
+timeCreated: 1627823630


### PR DESCRIPTION
This PR allows items to be spawned when all enemies in the room have been defeated.

To test, add an enemy to a room prefab (easiest is "RoomPlatedNESW" since it's the spawn room) and ensure that an item is spawned when the enemy is defeated.