### PR TITLE
Mouse and controller input adjustments

### DIFF
--- a/MicrowaveGame/Assets/Resources/Inputs/InputActionManager.inputactions
+++ b/MicrowaveGame/Assets/Resources/Inputs/InputActionManager.inputactions
@@ -298,6 +298,14 @@
                     "interactions": ""
                 },
                 {
+                    "name": "Look - Gamepad",
+                    "type": "Value",
+                    "id": "c628f8a4-c078-4d98-a682-987614af6422",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
                     "name": "Shoot",
                     "type": "Button",
                     "id": "76d6a890-e855-4609-817f-0841c729b487",
@@ -515,17 +523,6 @@
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
-                },
-                {
-                    "name": "",
-                    "id": "ac236a76-113a-4f13-af25-3008122ade97",
-                    "path": "<Gamepad>/rightStick",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Look",
-                    "isComposite": false,
-                    "isPartOfComposite": false
                 },
                 {
                     "name": "",
@@ -876,6 +873,28 @@
                     "processors": "",
                     "groups": "",
                     "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0bc5495b-cb12-42af-bbf2-9cbe6a830b30",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5232a887-a924-4ed1-b6a7-40ce0bf1fd7d",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Look - Gamepad",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/MicrowaveGame/Assets/Resources/Prefabs/Player/Player.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Player/Player.prefab
@@ -474,6 +474,22 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: 729a08b1-317a-4914-9120-3ee496c9e45d
     m_ActionName: Playing/Pause[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8573620642782398239}
+        m_TargetAssemblyTypeName: Scripts.Player.PlayerWeaponBehaviour, Assembly-CSharp
+        m_MethodName: OnLookGamepad
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: c628f8a4-c078-4d98-a682-987614af6422
+    m_ActionName: Playing/Look - Gamepad[/XInputControllerWindows/rightStick]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Playing

--- a/MicrowaveGame/Assets/Resources/Scripts/Player/PlayerWeaponBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Player/PlayerWeaponBehaviour.cs
@@ -46,6 +46,8 @@ namespace Scripts.Player
 		/// </summary>
 		public int AdditionalDamage { get; set; }
 
+		private Vector2 _lastMousePositionInWorld;
+
 		private void Start()
 		{
 			_defaultWeaponBehaviour = DefaultWeapon.GetComponent<WeaponBehaviour>();
@@ -58,6 +60,8 @@ namespace Scripts.Player
 
 		private void Update()
 		{
+			Direction = _lastMousePositionInWorld - (Vector2) transform.position;
+			
 			// default weapon is never instantiated so manually run update item method
 			_defaultWeaponBehaviour.OnUpdateItem(null);
 		}
@@ -69,10 +73,8 @@ namespace Scripts.Player
 		{
 			if (context.control.device.name == "Mouse")
 			{
-				// If the current device is keyboard and mouse, aim towards the cursor.
 				Vector2 mousePosition = Mouse.current.position.ReadValue();
-				Vector2 mousePositionInWorld = UnityEngine.Camera.main.ScreenToWorldPoint(mousePosition);
-				Direction = mousePositionInWorld - (Vector2) transform.position;
+				_lastMousePositionInWorld = UnityEngine.Camera.main.ScreenToWorldPoint(mousePosition);
 			}
 			else
 			{

--- a/MicrowaveGame/Assets/Resources/Scripts/Player/PlayerWeaponBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Player/PlayerWeaponBehaviour.cs
@@ -4,12 +4,13 @@ using UnityEngine.InputSystem;
 
 namespace Scripts.Player
 {
-    public class PlayerWeaponBehaviour : MonoBehaviour
+	public class PlayerWeaponBehaviour : MonoBehaviour
 	{
 		/// <summary>
 		/// The default weapon prefab.
 		/// </summary>
 		public GameObject DefaultWeapon;
+
 		private WeaponBehaviour _defaultWeaponBehaviour;
 
 
@@ -17,10 +18,11 @@ namespace Scripts.Player
 		/// The WeaponBehaviour of the currently equipped weapon.
 		/// </summary>
 		public WeaponBehaviour EquippedWeaponBehaviour
-		{ 
+		{
 			get => _equippedWeaponBehaviour;
 			set => _equippedWeaponBehaviour = value ?? _defaultWeaponBehaviour;
 		}
+
 		private WeaponBehaviour _equippedWeaponBehaviour;
 
 		/// <summary>
@@ -31,7 +33,8 @@ namespace Scripts.Player
 			get => _direction;
 			set => _direction = value.normalized;
 		}
-		private Vector2 _direction;
+
+		private Vector2 _direction = Vector2.up;
 
 
 		/// <summary>
@@ -40,12 +43,13 @@ namespace Scripts.Player
 		public bool Shooting { get; private set; }
 
 		private const float AimDeadzone = 0.1f;
-		
+
 		/// <summary>
 		/// Any additional animation the player may deal on top of the weapon's damage.
 		/// </summary>
 		public int AdditionalDamage { get; set; }
 
+		private bool _isCurrentInputMouse;
 		private Vector2 _lastMousePositionInWorld;
 
 		private void Start()
@@ -55,13 +59,12 @@ namespace Scripts.Player
 
 			// default weapon is never instantiated so manually run start method
 			_defaultWeaponBehaviour.Start();
-			
 		}
 
 		private void Update()
 		{
-			Direction = _lastMousePositionInWorld - (Vector2) transform.position;
-			
+			if (_isCurrentInputMouse) Direction = _lastMousePositionInWorld - (Vector2) transform.position;
+
 			// default weapon is never instantiated so manually run update item method
 			_defaultWeaponBehaviour.OnUpdateItem(null);
 		}
@@ -71,20 +74,21 @@ namespace Scripts.Player
 		/// </summary>
 		public void OnLook(InputAction.CallbackContext context)
 		{
-			if (context.control.device.name == "Mouse")
-			{
-				Vector2 mousePosition = Mouse.current.position.ReadValue();
-				_lastMousePositionInWorld = UnityEngine.Camera.main.ScreenToWorldPoint(mousePosition);
-			}
-			else
-			{
-				// If the current device is not keyboard and mouse, we assume it's a controller
-				// as it's the only other device specified in the InputActions file.
+			_isCurrentInputMouse = true;
 
-				// Aim in the direction of the right stick movement.
-				Vector2 value = context.ReadValue<Vector2>();
-				if (value.sqrMagnitude >= AimDeadzone) Direction = value;
-			}
+			Vector2 mousePosition = Mouse.current.position.ReadValue();
+			_lastMousePositionInWorld = (Vector2) UnityEngine.Camera.main.ScreenToWorldPoint(mousePosition);
+		}
+
+		/// <summary>
+		/// Called on look gamepad event from unity input system.
+		/// </summary>
+		public void OnLookGamepad(InputAction.CallbackContext context)
+		{
+			_isCurrentInputMouse = false;
+
+			Vector2 value = context.ReadValue<Vector2>();
+			if (value.sqrMagnitude >= AimDeadzone) Direction = value;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR makes it so bullets will always be fired towards the current mouse position.
Additionally, it also fixes controller looking not working.

To test, launch the game and ensure the bullet is always fired towards the mouse, and for the controller, that the bullet is fired in the direction the right joystick is currently in.