### PR TITLE
Fixed Level Traversal logic error

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
@@ -50,10 +50,7 @@ namespace Scripts.Levels
 			// CurrentRoom. So we can now disable any previous rooms knowing
 			// that they are outside the view of the camera.
 			if (_roomsToDisable.Count > 0 && _cameraPanBehaviour.IsStationary && !_levelGenerationBehaviour.DebugAlwaysShowRooms)
-			{
-				// Resume input and time as the changing room sequence has finished.
-				GameState.Resume();
-				
+			{				
 				_roomsToDisable.ForEach(room => room.SetActive(false));
 				_roomsToDisable.Clear();
 			}
@@ -69,11 +66,11 @@ namespace Scripts.Levels
 		{
 			// Don't attempt to change the room if the door is closed / locked.
 			if (!doorConnectionBehaviour.IsOpen) return;
-			
-			// Freeze input and time while changing room.
-			GameState.Pause();
-			
-			AudioManager.Play(doorConnectionBehaviour.EnterAudioClip);
+
+            // Freeze input and time while changing room.
+            GameState.Pause();
+
+            AudioManager.Play(doorConnectionBehaviour.EnterAudioClip);
 
 			// queue current room to be disabled
 			_roomsToDisable.Add(CurrentRoom.gameObject);
@@ -89,6 +86,8 @@ namespace Scripts.Levels
 			_player.transform.position = doorConnectionBehaviour.ConnectingDoor.transform.position
 									   + doorConnectionBehaviour.Direction.ToVector3()
 									   * 1.55f;
+			// Unfreeze input and time after changing room.
+			GameState.Resume();
 		}
 	}
 


### PR DESCRIPTION
The rooms were getting paused, but because Update() was getting called before the room was loaded to remove the previous room, the pause menu could be called because of the Resume function in Update. This was fixed by removing the Resume function from update, and moving it to after the player was moved.

Please verify that pressing pause on leaving rooms doesn't leave the timescale unchanged, on keyboard and controller.