### PR TITLE
Only resume play after room transition if in the playing menu

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
@@ -6,6 +6,7 @@ using Scripts.Camera;
 using Scripts.Utilities;
 using System;
 using Scripts.Events;
+using Scripts.Menus;
 
 namespace Scripts.Levels
 {
@@ -50,7 +51,10 @@ namespace Scripts.Levels
 			// CurrentRoom. So we can now disable any previous rooms knowing
 			// that they are outside the view of the camera.
 			if (_roomsToDisable.Count > 0 && _cameraPanBehaviour.IsStationary && !_levelGenerationBehaviour.DebugAlwaysShowRooms)
-			{				
+			{
+				// If we haven't paused during the transition, unfreeze input and time after changing room.
+				if (MenuManager.Current.name == "MenuPlaying") GameState.Resume();
+				
 				_roomsToDisable.ForEach(room => room.SetActive(false));
 				_roomsToDisable.Clear();
 			}
@@ -86,8 +90,6 @@ namespace Scripts.Levels
 			_player.transform.position = doorConnectionBehaviour.ConnectingDoor.transform.position
 									   + doorConnectionBehaviour.Direction.ToVector3()
 									   * 1.75f;
-			// Unfreeze input and time after changing room.
-			GameState.Resume();
 		}
 	}
 


### PR DESCRIPTION
This PR resolves the room transition issue.

As mentioned on the Trello card (see: https://trello.com/c/hQfUR4fN), even though #103 fixed the issue we were looking at, it undid the original intention behind it.

This finally resolves the issue by only resuming play after the room transition has finished if the menu is "MenuPlaying".

To test, pause the game as the room transitioning is underway. Enemies in the room shouldn't be animated / shooting and you shouldn't be able to move around. If you don't pause during a room transition, it should resume play once the transition is finished.