### PR TITLE
Bug Testing Fixes (v0.1.4)

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Hazards/HazardAcidSpill.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Hazards/HazardAcidSpill.prefab
@@ -91,9 +91,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Damage: 1
   DamageRate: 1
-  Duration: 5
-  AccelerationFactor: 0.5
-  FrictionFactor: 0.25
+  Duration: 2
 --- !u!1001 &1788020827790010284
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
@@ -81,7 +81,13 @@ MonoBehaviour:
   DialogueContent:
     Speaker: Merlin
     Sentences:
-    - I found it! With this I can restore power to Light City!
+    - 'I found it! With this I can restore power to Light City!
+
+      ### Engaging
+      Teleporter ###
+
+      --- Congratulations, you have completed the demo, you''re
+      welcome to play again ---'
 --- !u!1001 &1447312555054794971
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuCredits.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuCredits.prefab
@@ -110,7 +110,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 250, y: 0}
-  m_SizeDelta: {x: 500, y: 310}
+  m_SizeDelta: {x: 500, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5623186482671948352
 CanvasRenderer:
@@ -147,7 +147,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 48
-    m_Alignment: 1
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -207,8 +207,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -127.5}
-  m_SizeDelta: {x: 210, y: 58}
+  m_AnchoredPosition: {x: 0, y: -126}
+  m_SizeDelta: {x: 220, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5623186483124888983
 CanvasRenderer:
@@ -245,7 +245,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 48
-    m_Alignment: 1
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -423,7 +423,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -250, y: 0}
-  m_SizeDelta: {x: 500, y: 310}
+  m_SizeDelta: {x: 500, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5623186484038667575
 CanvasRenderer:
@@ -460,7 +460,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 48
-    m_Alignment: 1
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -493,6 +493,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5623186483246349086}
     m_Modifications:
+    - target: {fileID: 4821173537813569984, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
       propertyPath: m_RootOrder
       value: 5

--- a/MicrowaveGame/Assets/Resources/Scenes/Menu.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Menu.unity
@@ -513,6 +513,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 290342941}
     m_Modifications:
+    - target: {fileID: 5623186482671948354, guid: 8d30faa931206344f8f460c063dac881, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 330.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5623186482671948354, guid: 8d30faa931206344f8f460c063dac881, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10.35
+      objectReference: {fileID: 0}
     - target: {fileID: 5623186483246349073, guid: 8d30faa931206344f8f460c063dac881, type: 3}
       propertyPath: m_Name
       value: MenuCredits
@@ -604,6 +612,14 @@ PrefabInstance:
     - target: {fileID: 5623186483246349086, guid: 8d30faa931206344f8f460c063dac881, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5623186484038667593, guid: 8d30faa931206344f8f460c063dac881, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 330.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5623186484038667593, guid: 8d30faa931206344f8f460c063dac881, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10.35
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8d30faa931206344f8f460c063dac881, type: 3}

--- a/MicrowaveGame/Assets/Resources/Scenes/Menu.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Menu.unity
@@ -513,14 +513,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 290342941}
     m_Modifications:
-    - target: {fileID: 5623186482671948354, guid: 8d30faa931206344f8f460c063dac881, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 330.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5623186482671948354, guid: 8d30faa931206344f8f460c063dac881, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10.35
-      objectReference: {fileID: 0}
     - target: {fileID: 5623186483246349073, guid: 8d30faa931206344f8f460c063dac881, type: 3}
       propertyPath: m_Name
       value: MenuCredits
@@ -612,14 +604,6 @@ PrefabInstance:
     - target: {fileID: 5623186483246349086, guid: 8d30faa931206344f8f460c063dac881, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5623186484038667593, guid: 8d30faa931206344f8f460c063dac881, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 330.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5623186484038667593, guid: 8d30faa931206344f8f460c063dac881, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10.35
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8d30faa931206344f8f460c063dac881, type: 3}

--- a/MicrowaveGame/ProjectSettings/ProjectSettings.asset
+++ b/MicrowaveGame/ProjectSettings/ProjectSettings.asset
@@ -12,8 +12,8 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
-  productName: MicrowaveGame
+  companyName: Quasar Monkeys
+  productName: 'LED: Light Extraction Droid'
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -122,12 +122,12 @@ PlayerSettings:
   vulkanEnablePreTransform: 0
   vulkanEnableLateAcquireNextImage: 0
   m_SupportedAspectRatios:
-    4:3: 1
-    5:4: 1
+    4:3: 0
+    5:4: 0
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0
+  bundleVersion: 0.1.4
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}
@@ -149,7 +149,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Standalone: com.DefaultCompany.MicrowaveGame
+    Standalone: com.QuasarMonkeys.LEDLightExtractionDroid
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -260,7 +260,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: a7426d5ef88d38243a3d2837b2476b0b, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons: []
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsJobs:
@@ -566,8 +573,8 @@ PlayerSettings:
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
-  metroPackageName: 2D_BuiltInRenderer
-  metroPackageVersion: 
+  metroPackageName: 2DBuiltInRenderer
+  metroPackageVersion: 1.0.0.0
   metroCertificatePath: 
   metroCertificatePassword: 
   metroCertificateSubject: 
@@ -575,7 +582,7 @@ PlayerSettings:
   metroCertificateNotAfter: 0000000000000000
   metroApplicationDescription: 2D_BuiltInRenderer
   wsaImages: {}
-  metroTileShortName: 
+  metroTileShortName: MicrowaveGame
   metroTileShowName: 0
   metroMediumTileShowName: 0
   metroLargeTileShowName: 0


### PR DESCRIPTION
**Description**
Testing have been completed for Version 0.1.4 to be built and released Saturday 18th September.  A full list of feedback can be found in #bug-report on Discord.
This PR has made a few modest changes to improve the player experience

**Change Include:**
- Added Narrative Dialogue to Key Card pickup about being teleported and informing the player the demo is complete
- Poison damage duration reduced from 5 to 2
- Fixed Credits screen to include missing team members
- (Project Setting Changed for current build)

**Testing:**
Changes have been made across the game, you'll need to playthrough it's entirety and take notice of poison damage, the credits screen on the Menu and the key card pickup dialogue