### PR TITLE
Changed MenuNarrativeBehaviour and Hub scene

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
@@ -827,6 +827,24 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2251424065116161678, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
+      propertyPath: _strings.Array.data[0]
+      value: 'Welcome to L.E.D: Light Extraction Droid demo. You are about to assume
+        the role of Merlin, a robot working as a private detective who serves the
+        citizens of Light City'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2251424065116161678, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
+      propertyPath: _strings.Array.data[1]
+      value: Merlin has just taken back control of the Light City Power Grid from
+        the villainous Lightbulb Gang, who have stolen the keycards that provide
+        power to Light City
+      objectReference: {fileID: 0}
+    - target: {fileID: 2251424065116161678, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
+      propertyPath: _strings.Array.data[2]
+      value: Now, Merlin must infiltrate their place of operations known as the Lightclub,
+        and gain back control of the keycards. It is here that we join Merlin. Good
+        luck
+      objectReference: {fileID: 0}
+    - target: {fileID: 2251424065116161678, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
       propertyPath: DebugDisableBackgroundMusic
       value: 1
       objectReference: {fileID: 0}

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
@@ -16,9 +16,14 @@ namespace Scripts.Menus
 		/// </summary>
 		public bool DebugDisableBackgroundMusic;
 
-		[SerializeField]
-		[TextArea(3, 10)]
-		private string[] _strings;
+		/*[SerializeField]
+		[TextArea(3, 10)]*/
+		private string[] _strings =
+		{
+			"Welcome to L.E.D: Light Extraction Droid demo. You are about to assume the role of Merlin, a robot working as a private detective who serves the citizens of Light City",
+			"Merlin has just taken back control of the Light City Power Grid from the villainous Lightbulb Gang, who have stolen the keycards that provide power to Light City",
+			"Now, Merlin must infiltrate their place of operations known as the Lightclub, and gain back control of the keycards. It is here that we join Merlin. Good luck,"
+		};
 
 		private int _currentString;
 

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
@@ -16,12 +16,9 @@ namespace Scripts.Menus
 		/// </summary>
 		public bool DebugDisableBackgroundMusic;
 
-		private readonly string[] _strings =
-		{
-			"This is the story of Merlin. Merlin was a robot with one purpose: To microwave food. Unfortunately, after an incident involving a small child and a shiny spoon, Merlin was discarded at a scrapyard.",
-			"Whilst attempting to escape his situation, Merlin fell through a hole in a pile of scrap, into a hidden world beneath the scrapyard.",
-			"Here, we join Merlin as he is being accosted by a group of mechanical soldiers."
-		};
+		[SerializeField]
+		[TextArea(3, 10)]
+		private string[] _strings;
 
 		private int _currentString;
 


### PR DESCRIPTION
Changes to MenuNarrativeBehaviour:
- Removed readonly from _strings
- Added SerializeField and TextArea attributes to _strings
- _strings elements can now be edited in the Unity Editor

Changes to Hub
- Changed text displayed on MenuNarrative to better reflect the current state of the narrative

How to observe changes
- Check the MenuNarrativeBehaviour script to see programmatic changes
- Check MenuNarrative object to see Attribute additions in effect
- Playing Hub scene will show the changes to the text