### PR TITLE
Fix menu indicator positioning

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuBehaviour.cs
@@ -12,13 +12,15 @@ namespace Scripts.Menus
 	public abstract class MenuBehaviour : MonoBehaviour
 	{
 		public Selectable CurrentSelectable { get; set; }
-		public Lerped<Vector3> ButtonIndicatorPosition { get; private set; }
 
 		private Transform _buttonIndicatorTransform;
 
 		private void Update()
 		{
-			if (_buttonIndicatorTransform != null) _buttonIndicatorTransform.position = ButtonIndicatorPosition.Value;
+			if (_buttonIndicatorTransform != null)
+			{
+				_buttonIndicatorTransform.position = Vector3.Lerp(_buttonIndicatorTransform.position, CurrentSelectable.transform.position, 0.075f);
+			}
 		}
 
 		/// <summary>
@@ -56,11 +58,7 @@ namespace Scripts.Menus
 
 		private void InitButtonIndicator(Vector3 initialPosition)
 		{
-			if (_buttonIndicatorTransform != null)
-			{
-				ButtonIndicatorPosition = new Lerped<Vector3>(initialPosition, 0.075f, Easing.EaseInOut, true);
-				return;
-			}
+			if (_buttonIndicatorTransform != null) return;
 
 			_buttonIndicatorTransform = transform.Find("MenuButtonIndicator");
 			if (_buttonIndicatorTransform == null) return;
@@ -78,8 +76,7 @@ namespace Scripts.Menus
 
 			_buttonIndicatorTransform.Find("ImageLeft").GetComponent<RectTransform>().localPosition -= offset;
 			_buttonIndicatorTransform.Find("ImageRight").GetComponent<RectTransform>().localPosition += offset;
-
-			ButtonIndicatorPosition = new Lerped<Vector3>(initialPosition, 0.075f, Easing.EaseInOut, true);
+			_buttonIndicatorTransform.position = initialPosition;
 		}
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuBehaviour.cs
@@ -26,7 +26,7 @@ namespace Scripts.Menus
 		/// </summary>
 		public virtual void OnEnter()
 		{
-			CurrentSelectable = GetComponentsInChildren<Selectable>().FirstOrDefault();
+			CurrentSelectable ??= GetComponentsInChildren<Selectable>().FirstOrDefault();
 
 			if (CurrentSelectable != null)
 			{
@@ -56,7 +56,11 @@ namespace Scripts.Menus
 
 		private void InitButtonIndicator(Vector3 initialPosition)
 		{
-			if (_buttonIndicatorTransform != null) return;
+			if (_buttonIndicatorTransform != null)
+			{
+				ButtonIndicatorPosition = new Lerped<Vector3>(initialPosition, 0.075f, Easing.EaseInOut, true);
+				return;
+			}
 
 			_buttonIndicatorTransform = transform.Find("MenuButtonIndicator");
 			if (_buttonIndicatorTransform == null) return;

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuButtonBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuButtonBehaviour.cs
@@ -19,12 +19,6 @@ namespace Scripts.Menus
 
 			// Update the currently selected button reference for the current menu.
 			MenuManager.Current.CurrentSelectable = button;
-
-			// Update the button indicators if the menu has them.
-			if (MenuManager.Current.ButtonIndicatorPosition != null)
-			{
-				MenuManager.Current.ButtonIndicatorPosition.Value = MenuManager.Current.CurrentSelectable.transform.position;
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the menu indicator being off screen after changing menu and stops setting the default menu button after the first entry into a menu.

To test, launch the game and ensure that when you open, close, change room, and reopen the pause menu, the indicator is in the correct place.