### PR TITLE
Audio Updates - Pitch and Gameplay Loop

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
@@ -690,6 +690,7 @@ GameObject:
   - component: {fileID: 697041651}
   - component: {fileID: 697041654}
   - component: {fileID: 697041655}
+  - component: {fileID: 697041656}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -798,6 +799,102 @@ MonoBehaviour:
   height: 540
   onAwake: 1
   onUpdate: 1
+--- !u!82 &697041656
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 697041650}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: 9a2a50801f45f5a46a19412712e328ad, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 0.398
+  m_Pitch: 1
+  Loop: 1
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &741390243
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Scripts/Weapons/RapidFireWeaponBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Weapons/RapidFireWeaponBehaviour.cs
@@ -40,7 +40,7 @@ namespace Scripts.Weapons
 				float spreadAngle = Spread * Random.Range(0.0f, 1.0f) - (Spread/2.0f);
 				Vector2 spread = new Vector2(Mathf.Cos(spreadAngle), Mathf.Sin(spreadAngle));
 				Quaternion q = Quaternion.Euler(0, 0, spreadAngle);
-				AudioManager.Play(ShootAudioClip);
+				AudioManager.Play(ShootAudioClip, 0.75f, false, Random.Range(0.55f, 1.35f));
 				InstanceFactory.InstantiateProjectile(
 					ProjectilePrefab,
 					position,


### PR DESCRIPTION
**Description**
The Player Weapon has been updated to allow pitch modulation of the sound effect, applying a rnd float  to the pitch each time it is called.

**Changes**
- Gameplay Loop Music has been reenabled
- AudioManager has been updated to allow for pitch modulation to be added to a method call's parameter 
- Player Weapon has the pitch modulation applied 

**Testing**
Jump in game and shoot around the gameplay scene, you can hear different pitches of the weapon