### PR TITLE
Added door Collider fix

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Doors/DoorConnectionBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Doors/DoorConnectionBehaviour.cs
@@ -51,6 +51,9 @@ namespace Scripts.Doors
 
 			GetComponent<SpriteRenderer>().sprite = OpenDoorSprite;
 			GetComponent<Animator>().Play("DoorPulsateOut");
+
+			// Enables door collider when being reopened.
+			GetComponent<Collider2D>().enabled = true;
 		}
 
 		/// <summary>
@@ -60,7 +63,9 @@ namespace Scripts.Doors
 		{
 			GetComponent<SpriteRenderer>().sprite = ClosedDoorSprite;
 			GetComponent<Animator>().Play("DoorPulsateIn");
-
+			
+			// Disables door collider while closed.
+			GetComponent<Collider2D>().enabled = false;
 			IsOpen = false;
 		}
 


### PR DESCRIPTION
Doors on close now no longer have an enable collider, and when opening them, they do have to reenable the disabled collider.
Please see if I missed an Issue.

Closed doors(N,S,E,W) Need to be checked for any sign of the collider sticking,
Open Doors(N,E,S,W(After Close) need to be checked if they can be passed through.