### PR TITLE
Destroy Projectiles fix

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelTraversalBehaviour.cs
@@ -79,6 +79,18 @@ namespace Scripts.Levels
 			// queue current room to be disabled
 			_roomsToDisable.Add(CurrentRoom.gameObject);
 
+			// disable projectiles of enemies
+			foreach (GameObject LightBulb in GameObject.FindObjectsOfType<GameObject>())
+				if (LightBulb.name == "ProjectileLightBulb(Clone)") Destroy(LightBulb);
+
+			// disable projectiles of Default weapon
+			foreach (GameObject Bullet in GameObject.FindObjectsOfType<GameObject>())
+				if (Bullet.name == "ProjectileWeaponDefault(Clone)") Destroy(Bullet);
+
+			// disable projectiles of Upgraded weapon
+			foreach (GameObject Slug in GameObject.FindObjectsOfType<GameObject>())
+				if (Slug.name == "ProjectileWeaponRapidFire(Clone)") Destroy(Slug);
+
 			// find and enable the connecting room
 			RoomConnectionBehaviour connectingRoom = doorConnectionBehaviour.ConnectingDoor.GetComponentsInParent<RoomConnectionBehaviour>(true)[0];
 			_roomsToDisable.Remove(connectingRoom.gameObject); // ensure the connecting room is not queued to be disabled


### PR DESCRIPTION
Added a foreach loop to the LevelTraversalBehaviour script for each type of projectile available. I did this because If I did one at a time,   it ignores some projectiles.

Please make sure projectiles are destroyed on room transitions, both default and rapid fire.