### PR TITLE
Fix Spike Trap Colliders

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomIndustrial/RoomIndustrialNE.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomIndustrial/RoomIndustrialNE.prefab
@@ -422,6 +422,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Size.y
+      value: 4.628166
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Offset.y
+      value: -0.25428486
+      objectReference: {fileID: 0}
     - target: {fileID: 9129061225497907391, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Name
       value: HazardSpike (2)
@@ -478,6 +486,14 @@ PrefabInstance:
     - target: {fileID: 2133508884982593927, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Size.y
+      value: 5.0640836
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Offset.y
+      value: 0.21795821
       objectReference: {fileID: 0}
     - target: {fileID: 9129061225497907391, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Name
@@ -763,6 +779,14 @@ PrefabInstance:
     - target: {fileID: 2133508884982593927, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Size.y
+      value: 4.6644926
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Offset.y
+      value: 0.27244806
       objectReference: {fileID: 0}
     - target: {fileID: 9129061225497907391, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Name

--- a/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomIndustrial/RoomIndustrialNE.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomIndustrial/RoomIndustrialNE.prefab
@@ -427,6 +427,10 @@ PrefabInstance:
       value: 4.628166
       objectReference: {fileID: 0}
     - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Offset.y
       value: -0.25428486
       objectReference: {fileID: 0}
@@ -490,6 +494,10 @@ PrefabInstance:
     - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Size.y
       value: 5.0640836
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Offset.y
@@ -782,11 +790,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Size.y
-      value: 4.6644926
+      value: 14.562998
       objectReference: {fileID: 0}
     - target: {fileID: 6494221438679168687, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Offset.y
-      value: 0.27244806
+      value: 0.31785393
       objectReference: {fileID: 0}
     - target: {fileID: 9129061225497907391, guid: 411e5bfa267c3d5458199db7ccff7e5d, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
**Description**

In previous PR testing, I noticed the NE Spike Trap Room could cause the players to become over damaged and lose, to make it fairer, there is now just one collider

**Changes Made**

- Updated the Spike Trap Colliders in NE to have one active collider, instead of three

**Testing**

Jump into a game and encounter the NE Room with the three spike traps and conveyor belts