### PR TITLE
Fix keyboard bindings listing in controls menu

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuControls.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuControls.prefab
@@ -88,10 +88,10 @@ MonoBehaviour:
 
     E
 
-    1, 2,
-    3, 4 Keys
+    Shift
+    + 1, 2, 3, 4 Keys
 
-    Shift + 1, 2, 3, 4 Keys
+    1, 2, 3, 4 Keys
 
     Escape'
 --- !u!1 &2564488589942413394


### PR DESCRIPTION
This PR fixes the whoopsie I made when I initially added the keyboard bindings listing to the controls menu.
To test, ensure the keyboard & mouse bindings listings in the controls menu is correct.