### PR TITLE
Player collider adjustments

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
@@ -450,7 +450,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2945509771218161467, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2945509771218161467, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -490,6 +490,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2945509771218161467, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4252811419457458747, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
+      propertyPath: m_IsTrigger
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -667,6 +671,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f744935fe0911bd429ec22e26374b6ca, type: 3}
+--- !u!1001 &669047469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 19021472582998992, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_Name
+      value: RoomIndustrialNE
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.4362898
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6999221
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
 --- !u!1 &697041650
 GameObject:
   m_ObjectHideFlags: 0
@@ -894,7 +955,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3898991143064732530, guid: 609cf602cf9281a43b8d880e025129ec, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3898991143064732530, guid: 609cf602cf9281a43b8d880e025129ec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1373,7 +1434,7 @@ RectTransform:
   - {fileID: 51205459}
   - {fileID: 77326880}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1457,7 +1518,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1782651768
 PrefabInstance:

--- a/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
@@ -450,7 +450,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2945509771218161467, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2945509771218161467, guid: 71a2878986dd1e048b0d34eac7a690b9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -671,63 +671,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f744935fe0911bd429ec22e26374b6ca, type: 3}
---- !u!1001 &669047469
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 19021472582998992, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_Name
-      value: RoomIndustrialNE
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.4362898
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.6999221
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844452504437847073, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9445650363fa62c459f53da970e6a91f, type: 3}
 --- !u!1 &697041650
 GameObject:
   m_ObjectHideFlags: 0
@@ -955,7 +898,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3898991143064732530, guid: 609cf602cf9281a43b8d880e025129ec, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3898991143064732530, guid: 609cf602cf9281a43b8d880e025129ec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1434,7 +1377,7 @@ RectTransform:
   - {fileID: 51205459}
   - {fileID: 77326880}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1518,7 +1461,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1782651768
 PrefabInstance:

--- a/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardAcidSpillBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardAcidSpillBehaviour.cs
@@ -25,10 +25,13 @@ namespace Scripts.Hazards
 		public AudioClip sfx;
 		private void OnTriggerStay2D(Collider2D other)
 		{
-			StatusEffectBehaviour statusEffectBehaviour = other.gameObject.GetComponent<StatusEffectBehaviour>();
-			if (statusEffectBehaviour != null)
+			if (other.gameObject.name == "Wheel")
 			{
-				statusEffectBehaviour.Apply<StatusEffectMelting>(Duration, Damage, DamageRate,sfx);
+				StatusEffectBehaviour statusEffectBehaviour = other.gameObject.GetComponentInParent<StatusEffectBehaviour>();
+				if (statusEffectBehaviour != null)
+				{
+					statusEffectBehaviour.Apply<StatusEffectMelting>(Duration, Damage, DamageRate, sfx);
+				}
 			}
 		}
 	}

--- a/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardOilSpillBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardOilSpillBehaviour.cs
@@ -25,11 +25,14 @@ namespace Scripts.Hazards
 		public AudioClip sfx;
 		private void OnTriggerStay2D(Collider2D other)
 		{
-			StatusEffectBehaviour statusEffectBehaviour = other.gameObject.GetComponent<StatusEffectBehaviour>();
-
-			if (statusEffectBehaviour != null)
+			if (other.gameObject.name == "Wheel")
 			{
-				statusEffectBehaviour.Apply<StatusEffectSlower>(Duration, AccelerationFactor, FrictionFactor, sfx);
+				StatusEffectBehaviour statusEffectBehaviour = other.gameObject.GetComponentInParent<StatusEffectBehaviour>();
+
+				if (statusEffectBehaviour != null)
+				{
+					statusEffectBehaviour.Apply<StatusEffectSlower>(Duration, AccelerationFactor, FrictionFactor, sfx);
+				}
 			}
 		}
 

--- a/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardSpikeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Hazards/HazardSpikeBehaviour.cs
@@ -58,19 +58,21 @@ namespace Scripts.Hazards
 
 		private void OnTriggerEnter2D(Collider2D other)
 		{
-			if (other.gameObject.name != "Player") return;
-			_colliding = true;
-
-			_playerMovementBehaviour.MaxVelocity *= SlowdownFactor;
-			_time = _damageRateInverse;
+			if(other.gameObject.name == "Wheel")
+            {
+				_colliding = true;
+				_playerMovementBehaviour.MaxVelocity *= SlowdownFactor;
+				_time = _damageRateInverse;
+			}
 		}
 
 		private void OnTriggerExit2D(Collider2D other)
 		{
-			if (other.gameObject.name != "Player") return;
-
-			_colliding = false;
-			_playerMovementBehaviour.MaxVelocity /= SlowdownFactor;
+			if(other.gameObject.name == "Wheel")
+            {
+				_colliding = false;
+				_playerMovementBehaviour.MaxVelocity /= SlowdownFactor;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I adjusted ground based hazards to only look for wheels, and by default, other hazards and enemies only look for the player.
Please check these hazards only hit Merlin's wheel:

- [ ] Water Puddle
- [ ] Acid Pool
- [ ] Spikes
- [ ] Conveyor Belts(Both Types)