### PR TITLE
Fixed camera breaking when building the game

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Camera/CameraPanBehaviour.cs.meta
+++ b/MicrowaveGame/Assets/Resources/Scripts/Camera/CameraPanBehaviour.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -1
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
## Description
This PR fixes the issue where building the game results in the camera showing nothing but  the HUD.


## How to test
Build the game out and ensure the game plays properly.