### PR TITLE
Updated attacking requirements

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyCharger/EnemyChargerBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyCharger/EnemyChargerBehaviour.cs
@@ -100,10 +100,20 @@ namespace Scripts.Enemies.EnemyCharger
 		/// </summary>
 		public void Fire()
 		{
-			_lazerUpInstance = GameObject.Instantiate(_lazerUpPrefab, _projectileSpawn.position + _lazerUpOffset, Quaternion.identity);
-			_lazerDownInstance = GameObject.Instantiate(_lazerDownPrefab, _player.transform.position + _lazerDownOffset, Quaternion.identity);
-			_lazerDownInstance.AddComponent<LazerDownDamageBehaviour>();
-			AudioManager.Play(chargeSfx);
+			if (_player.GetComponent<HealthBehaviour>().Value <= 0 &&
+				_animator.GetCurrentAnimatorStateInfo(0).IsName("Charge") ||
+				_animator.GetCurrentAnimatorStateInfo(0).IsName("EnemyChargerLocate") ||
+				_animator.GetCurrentAnimatorStateInfo(0).IsName("Fire"))
+			{
+				_animator.Play("Idle");
+			}
+			else
+			{
+				_lazerUpInstance = GameObject.Instantiate(_lazerUpPrefab, _projectileSpawn.position + _lazerUpOffset, Quaternion.identity);
+				_lazerDownInstance = GameObject.Instantiate(_lazerDownPrefab, _player.transform.position + _lazerDownOffset, Quaternion.identity);
+				_lazerDownInstance.AddComponent<LazerDownDamageBehaviour>();
+				AudioManager.Play(chargeSfx);
+			}
 
 		}
 		

--- a/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyLamp/EnemyLampShootBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyLamp/EnemyLampShootBehaviour.cs
@@ -48,18 +48,25 @@ namespace Scripts.Enemies.EnemyLamp
 		/// <summary>
 		/// Shoot a projectile, this is called by a callback within the lamps
 		/// animations.
-		/// </summary>
+		/// </summary>d
 		public void Shoot(int direction)
 		{
-			InstanceFactory.InstantiateProjectile(
+			if (_player.GetComponent<HealthBehaviour>().Value <= 0 && _animator.GetCurrentAnimatorStateInfo(0).IsName("Shoot"))
+			{
+				_animator.Play("Idle");
+			}
+			else
+			{
+				InstanceFactory.InstantiateProjectile(
 				ProjectilePrefab,
 				_projectileSpawn.position,
 				_shootingDirection,
 				ProjectileSpeed,
 				ProjectileDamage,
 				"Player"
-			);
-			AudioManager.Play(weaponSfx, 0.55f, false, Random.Range(0.85f, 1.25f));
+				);
+				AudioManager.Play(weaponSfx, 0.55f, false, Random.Range(0.85f, 1.25f));
+			}
 		}
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyZapper/EnemyZapperBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Enemies/EnemyZapper/EnemyZapperBehaviour.cs
@@ -23,7 +23,8 @@ namespace Scripts.Enemies.EnemyZapper
 		public Vector2 Direction { get; private set; }
 
 		private bool IsWalking => _animator.GetCurrentAnimatorStateInfo(0).IsName("Walk");
-		
+
+		private GameObject _player;
 		private Rigidbody2D _rigidBody;
 		private Animator _animator;
 		private GameObject _shockGameObject;
@@ -33,6 +34,7 @@ namespace Scripts.Enemies.EnemyZapper
 		{
 			Direction = Vector2.up;
 
+			_player = GameObject.Find("Player");
 			_rigidBody = GetComponent<Rigidbody2D>();
 			_animator = GetComponent<Animator>();
 			_shockGameObject = Resources.Load<GameObject>("Prefabs/Enemies/EnemyZapper/EnemyZapperShock");
@@ -64,8 +66,17 @@ namespace Scripts.Enemies.EnemyZapper
 		/// </summary>
 		public void Attack()
 		{
-			Instantiate(_shockGameObject, transform.position + new Vector3(0, 0.5f, 0), Quaternion.identity);
-			AudioManager.Play(weaponSfx, 0.55f, false, Random.Range(0.85f, 1.25f));
+			if (_player.GetComponent<HealthBehaviour>().Value <= 0 && 
+				(_animator.GetCurrentAnimatorStateInfo(0).IsName("Attack") || 
+				_animator.GetCurrentAnimatorStateInfo(0).IsName("Charge")))
+			{
+				_animator.Play("Walk");
+			}
+			else
+			{
+				Instantiate(_shockGameObject, transform.position + new Vector3(0, 0.5f, 0), Quaternion.identity);
+				AudioManager.Play(weaponSfx, 0.55f, false, Random.Range(0.85f, 1.25f));
+			}
 		}
 
 		private void FixedUpdate()


### PR DESCRIPTION
Changed requirements for Attacking animation to play for enemies. Specifically not to attack when the player has 0 health.
Please ensure after initial death cycle,
- [ ] Lamp does not shoot at player after death.
- [ ] zapper does not discharge upon merlin's death,
- [ ] charger does not Lazer after merlin's death,