### PR TITLE
Update selected slot on use

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
@@ -204,7 +204,7 @@ namespace Scripts.Inventory
 		/// <summary>
 		/// Updates the slot indicator's visibility and position.
 		/// </summary>
-		/// <param name="inventorySlotBehaviour">If one is given, assume we're picking up an item. Otherwise, assuming we're dropping an item.</param>
+		/// <param name="inventorySlotBehaviour">If one is given, assume we're picking up an item. Otherwise, assume we're dropping an item.</param>
 		public void UpdateSlotIndicator(InventorySlotBehaviour inventorySlotBehaviour = null)
 		{
 			if (inventorySlotBehaviour != null && !_inventorySlotIndicatorBehaviour.Visible)

--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
@@ -77,12 +77,7 @@ namespace Scripts.Inventory
 			nextAvailableSlot.PickupItem(selectedItem);
 			selectedItem.gameObject.SetActive(false);
 
-			// If the slot indicator is invisible, make it visible and move it to the new slot.
-			if (!_inventorySlotIndicatorBehaviour.Visible)
-			{
-				_inventorySlotIndicatorBehaviour.MoveTo(nextAvailableSlot.transform.localPosition, true);
-				_inventorySlotIndicatorBehaviour.Visible = true;
-			}
+			UpdateSlotIndicator(nextAvailableSlot);
 
 			AudioManager.Play(PickupItemAudioClip);
 		}
@@ -100,27 +95,7 @@ namespace Scripts.Inventory
 			ItemBehaviour itemBehaviour = _slots[_currentSlotIndex].DropItem();
 			if (itemBehaviour == null) return;
 
-			int nextSlotIndex = -1;
-
-			for (int i = 0; i < _slots.Length; i++)
-			{
-				if (_slots[i].ItemBehaviour != null)
-				{
-					nextSlotIndex = i;
-					break;
-				}
-			}
-
-			// If there's a slot with an item, set it as the current slot and move the indicator to it.
-			// Otherwise hide the indicator.
-			if (nextSlotIndex != -1)
-			{
-				_currentSlotIndex = nextSlotIndex;
-
-				_inventorySlotIndicatorBehaviour.Visible = true;
-				_inventorySlotIndicatorBehaviour.MoveTo(_slots[_currentSlotIndex].transform.localPosition);
-			}
-			else _inventorySlotIndicatorBehaviour.Visible = false;
+			UpdateSlotIndicator();
 
 			itemBehaviour.transform.position = _player.transform.position;
 			itemBehaviour.gameObject.SetActive(true);
@@ -223,6 +198,45 @@ namespace Scripts.Inventory
 		public void RemoveNearbyItem(ItemBehaviour itemBehaviour)
 		{
 			if (itemBehaviour != null && _nearbyItems.Contains(itemBehaviour)) _nearbyItems.Remove(itemBehaviour);
+		}
+
+
+		/// <summary>
+		/// Updates the slot indicator's visibility and position.
+		/// </summary>
+		/// <param name="inventorySlotBehaviour">If one is given, assume we're picking up an item. Otherwise, assuming we're dropping an item.</param>
+		public void UpdateSlotIndicator(InventorySlotBehaviour inventorySlotBehaviour = null)
+		{
+			if (inventorySlotBehaviour != null && !_inventorySlotIndicatorBehaviour.Visible)
+			{
+				// If the slot indicator is invisible, make it visible and move it to the new slot.
+				_inventorySlotIndicatorBehaviour.MoveTo(inventorySlotBehaviour.transform.localPosition, true);
+				_inventorySlotIndicatorBehaviour.Visible = true;
+			}
+			else
+			{
+				int nextSlotIndex = -1;
+
+				for (int i = 0; i < _slots.Length; i++)
+				{
+					if (_slots[i].ItemBehaviour != null)
+					{
+						nextSlotIndex = i;
+						break;
+					}
+				}
+
+				// If there's a slot with an item, set it as the current slot and move the indicator to it.
+				// Otherwise hide the indicator.
+				if (nextSlotIndex != -1)
+				{
+					_currentSlotIndex = nextSlotIndex;
+
+					_inventorySlotIndicatorBehaviour.Visible = true;
+					_inventorySlotIndicatorBehaviour.MoveTo(_slots[_currentSlotIndex].transform.localPosition);
+				}
+				else _inventorySlotIndicatorBehaviour.Visible = false;
+			}
 		}
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
@@ -17,6 +17,8 @@ namespace Scripts.Inventory
 
 		private Animator _animator;
 
+		private static InventoryBehaviour _inventoryBehaviour;
+
 		private void Start()
 		{
 			_inventorySpriteRenderer = transform.Find("Animator/Sprite").GetComponent<SpriteRenderer>();
@@ -25,6 +27,8 @@ namespace Scripts.Inventory
 			_inventorySlotInitialScale = transform.Find("Background").localScale;
 
 			_animator = GetComponentInChildren<Animator>();
+
+			_inventoryBehaviour = GameObject.Find("Inventory").GetComponent<InventoryBehaviour>();
 		}
 
 		private void Update()
@@ -70,6 +74,8 @@ namespace Scripts.Inventory
 
 			ItemBehaviour itemBehaviour = ItemBehaviour;
 			ItemBehaviour = null;
+
+			_inventoryBehaviour.UpdateSlotIndicator();
 
 			return itemBehaviour;
 		}

--- a/MicrowaveGame/Assets/Resources/Scripts/Items/ItemSpeedIncreaseBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Items/ItemSpeedIncreaseBehaviour.cs
@@ -17,7 +17,8 @@ namespace Scripts.Items
 		/// </summary>
 		public int DurationValue;
 
-		private bool _isUsed;
+		private bool _isActive, _isUsed;
+		private float _time;
 
 		public AudioClip itemDrop;
 
@@ -32,24 +33,38 @@ namespace Scripts.Items
 
 		public override void OnUseItem(InventorySlotBehaviour inventorySlotBehaviour)
 		{
-			_isUsed = true;
+			if (_isActive) return;
+			_isActive = _isUsed = true;
 
 			GameObject.Find("Player").GetComponent<StatusEffectBehaviour>()
 				.Apply<StatusEffectFaster>(DurationValue, IncreaseValue);
 
-			inventorySlotBehaviour.PlayAnimation("InventorySlotBounceExpand");
+			inventorySlotBehaviour.PlayAnimation("InventorySlotBounceLoop");
+		}
+
+		public override void OnUpdateItem(InventorySlotBehaviour inventorySlotBehaviour)
+		{
+			if (!_isActive) return;
+
+			_time += Time.deltaTime;
+			if (_time < DurationValue) return;
+
+			_isActive = false;
+
+			inventorySlotBehaviour.PlayAnimation("InventorySlotBounceContract");
 			inventorySlotBehaviour.DropItem();
 			Destroy(gameObject);
 		}
 
-		public override void OnUpdateItem(InventorySlotBehaviour inventorySlotBehaviour) { }
-
 		public override bool OnDropItem(InventorySlotBehaviour inventorySlotBehaviour)
 		{
-			if (!_isUsed) inventorySlotBehaviour.PlayAnimation("InventorySlotBounceContract");
-			AudioManager.Play(itemDrop, 0.55f);
-			return true;
+			if (!_isUsed)
+			{
+				inventorySlotBehaviour.PlayAnimation("InventorySlotBounceContract");
+				AudioManager.Play(itemDrop, 0.55f);
+			}
 
+			return !_isActive;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a a bug where using a cooldown / duration item wouldn't update the select slot indicator.

To test, ensure when the speed increase item has finished being used that the slot indicator moves to another item, or hides if no other items are in the inventory.