### PR TITLE
Item swapping behaviour fix

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventoryBehaviour.cs
@@ -67,7 +67,7 @@ namespace Scripts.Inventory
 			{
 				// All inventory slots are taken.
 				// Swap the current item with the nearby item.
-				OnDropItem(context);
+				OnDropItem(context, false);
 				OnPickupItem(context);
 
 				return;
@@ -85,17 +85,24 @@ namespace Scripts.Inventory
 		/// <summary>
 		/// Drops an item if one is in the slot.
 		/// Called by the "drop item" input action.
+		/// <param name="context">The context of the input action.</param>
+		/// </summary>
+		public void OnDropItem(InputAction.CallbackContext context) => OnDropItem(context, true);
+
+		/// <summary>
+		/// Drops an item if one is in the slot.
 		/// </summary>
 		/// <param name="context">The context of the input action.</param>
-		public void OnDropItem(InputAction.CallbackContext context)
+		/// <param name="swapping">Whether or not the current slot is performing a swap behaviour.</param>
+		private void OnDropItem(InputAction.CallbackContext context, bool swapping)
 		{
 			if (!SceneManager.GetActiveScene().isLoaded) return;
 			if (!context.performed) return;
 
-			ItemBehaviour itemBehaviour = _slots[_currentSlotIndex].DropItem();
+			ItemBehaviour itemBehaviour = _slots[_currentSlotIndex].DropItem(swapping);
 			if (itemBehaviour == null) return;
 
-			UpdateSlotIndicator();
+			if (swapping) UpdateSlotIndicator();
 
 			itemBehaviour.transform.position = _player.transform.position;
 			itemBehaviour.gameObject.SetActive(true);

--- a/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Inventory/InventorySlotBehaviour.cs
@@ -62,8 +62,9 @@ namespace Scripts.Inventory
 		/// <summary>
 		/// Attempt to drop the item if there is one in the slot.
 		/// </summary>
+		/// <param name="swapping">Whether or not the current slot is performing a swap behaviour.</param>
 		/// <returns>The dropped item (null if empty).</returns>
-		public ItemBehaviour DropItem()
+		public ItemBehaviour DropItem(bool swapping = true)
 		{
 			if (ItemBehaviour == null) return null;
 
@@ -75,7 +76,7 @@ namespace Scripts.Inventory
 			ItemBehaviour itemBehaviour = ItemBehaviour;
 			ItemBehaviour = null;
 
-			_inventoryBehaviour.UpdateSlotIndicator();
+			if (swapping) _inventoryBehaviour.UpdateSlotIndicator();
 
 			return itemBehaviour;
 		}
@@ -111,6 +112,14 @@ namespace Scripts.Inventory
 			_inventorySpriteRenderer.sprite = sprite;
 		}
 
-		public void PlayAnimation(string name) => _animator.Play(name);
+		public void PlayAnimation(string name)
+		{
+			// In order to stop the current animation, we must play the given animation
+			// with it starting at the last frame so it immediately finishes.
+			// Then we can play the the given animation normally.
+
+			_animator.Play(name, 0, 1.0f);
+			_animator.Play(name);
+		}
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Projectiles/ProjectileBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Projectiles/ProjectileBehaviour.cs
@@ -65,7 +65,7 @@ namespace Scripts.Projectiles
 			// Destroy when impacting solid objects
 			if (tagBehaviour.HasTag("Solid"))
 			{
-				if (gameObject.name == "ProjectileWeaponDefault(Clone)"|| gameObject.name == "ProjectileWeaponRapidFire(Clone") Sparks();
+				if (gameObject.name == "ProjectileBullet(Clone)") Sparks();
 				Destroy(gameObject);
 			}
 


### PR DESCRIPTION
This PR makes it so the swapping behaviour won't change the selected slot. Additionally, this also re-adds the player bullet collison particle effects that I had unknowingly broke in a previous PR.

Changes are:

* Re-add player bullet collision particle effects (e435d60931af2463112921579771c4c5054161fe).
* Don't change the selected slot if we're swapping items (0633ead30e9ec89d57a4b7ec8cdf40ffabcb4e11).

To test, fill the player's inventory and attempt to pick up another item on any slot other than the first. The selected slot indicator should not move. Additionally, ensure the player bullet collision particle effects now work again when colliding with walls.