### PR TITLE
Add key card count display

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemHealthIncrease.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemHealthIncrease.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnProbability: 1
   Name: Health Increase
-  Description: Heals player damage by {0}
+  Description: Heals the player by {0}
   IncreaseValue: 2
   itemDrop: {fileID: 8300000, guid: de9efefb18faa6948be43037f07b07ca, type: 3}
   healthSFX: {fileID: 8300000, guid: 4a38517e9f642094289d793586a90767, type: 3}

--- a/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomHub/RoomHubSW.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Rooms/RoomHub/RoomHubSW.prefab
@@ -629,7 +629,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9073314109375800966}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.63, y: 0.23, z: 0}
+  m_LocalPosition: {x: 4.5, y: 0.55, z: 0}
   m_LocalScale: {x: 2.547582, y: 2.547582, z: 2.547582}
   m_Children: []
   m_Father: {fileID: 5322624418239999354}
@@ -806,6 +806,63 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &148408502705903539
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5322624418239999354}
+    m_Modifications:
+    - target: {fileID: 1562560908494916396, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_Name
+      value: EndingDoorChevron
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
 --- !u!1001 &756970386408660985
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -823,11 +880,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.63
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.42
+      value: -2.25
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1101,11 +1158,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.99
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.44
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1158,11 +1215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.17
+      value: 7.25
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.44
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8807240334975731619, guid: d1f5d9239871d5247ad1d85582269d60, type: 3}
       propertyPath: m_LocalPosition.z

--- a/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
@@ -148,7 +148,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5794048396616728324, guid: 144c13c09b1619746941aa827c09675c, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 5794048396616728324, guid: 144c13c09b1619746941aa827c09675c, type: 3}
       propertyPath: m_AnchorMax.x
@@ -250,7 +250,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
       propertyPath: m_AnchorMax.x
@@ -335,63 +335,135 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
   m_PrefabInstance: {fileID: 77326879}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &378656318
-PrefabInstance:
+--- !u!1 &136599200
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1671621497}
-    m_Modifications:
-    - target: {fileID: 3684964746714219147, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_Name
-      value: RoomHubSW
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 136599201}
+  - component: {fileID: 136599202}
+  m_Layer: 5
+  m_Name: CardCountDisplay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &136599201
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136599200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1681853311}
+  - {fileID: 223219234}
+  m_Father: {fileID: 1303808621}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 552.5, y: 322.56}
+  m_SizeDelta: {x: 150, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &136599202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136599200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0bf0aff5b874b39bda3a6db525d7457, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &223219233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 223219234}
+  - component: {fileID: 223219236}
+  - component: {fileID: 223219235}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &223219234
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223219233}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 136599201}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 25, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &223219235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223219233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 7c6167e879fc69cd79d23cc3ff3103bb, type: 3}
+    m_FontSize: 36
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 72
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &223219236
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223219233}
+  m_CullTransparentMesh: 1
 --- !u!1001 &380900815
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -417,7 +489,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7333766769061139434, guid: f0d89f81af97b914da3eeac9eec64f20, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7333766769061139434, guid: f0d89f81af97b914da3eeac9eec64f20, type: 3}
       propertyPath: m_AnchorMax.x
@@ -989,7 +1061,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1136289162091159327, guid: a35466c089d585383ba0857f4864e756, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1136289162091159327, guid: a35466c089d585383ba0857f4864e756, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1184,7 +1256,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2564488590833238210, guid: b664bc712c6a38e41b4d6977dbe81bc4, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2564488590833238210, guid: b664bc712c6a38e41b4d6977dbe81bc4, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1422,6 +1494,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 773961026}
+  - {fileID: 136599201}
   - {fileID: 1782651769}
   - {fileID: 380900816}
   - {fileID: 1839353660}
@@ -1439,6 +1512,63 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &1385586311
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1671621497}
+    m_Modifications:
+    - target: {fileID: 3684964746714219147, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_Name
+      value: RoomHubSW
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5322624418239999354, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d0e1e2dcbaca7b4893ec46d174fd834, type: 3}
 --- !u!1 &1527350666
 GameObject:
   m_ObjectHideFlags: 0
@@ -1518,6 +1648,81 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3898991143064732530, guid: 609cf602cf9281a43b8d880e025129ec, type: 3}
   m_PrefabInstance: {fileID: 741390243}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1681853310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1681853311}
+  - component: {fileID: 1681853313}
+  - component: {fileID: 1681853312}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1681853311
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1681853310}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 136599201}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -50, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1681853312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1681853310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: fa25a017579db654fa1049115e0cd699, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1681853313
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1681853310}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1782651768
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1543,7 +1748,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6289347686327385835, guid: eb9f20cc5db92c54090e74a5a059e5dc, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6289347686327385835, guid: eb9f20cc5db92c54090e74a5a059e5dc, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1649,7 +1854,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4076494359803435433, guid: 0911c58c2403b814f8a3f9986dcb1e7e, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4076494359803435433, guid: 0911c58c2403b814f8a3f9986dcb1e7e, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1804,7 +2009,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2251424065116161677, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 2251424065116161677, guid: de6e6edbe76606a4f935e4398727deba, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1909,7 +2114,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772921886234655895, guid: 43dde89c4b7a90540a71d2a9c371a685, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4772921886234655895, guid: 43dde89c4b7a90540a71d2a9c371a685, type: 3}
       propertyPath: m_AnchorMax.x

--- a/MicrowaveGame/Assets/Resources/Scripts/CardCountDisplayBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/CardCountDisplayBehaviour.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Scripts
+{
+	public class CardCountDisplayBehaviour : MonoBehaviour
+	{
+		private void Start()
+		{
+			GetComponentInChildren<Text>().text =
+				$"{Persistent.CollectedKeyCardCount} / {Persistent.RequiredKeyCardCount}";
+		}
+	}
+}

--- a/MicrowaveGame/Assets/Resources/Scripts/CardCountDisplayBehaviour.cs.meta
+++ b/MicrowaveGame/Assets/Resources/Scripts/CardCountDisplayBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0bf0aff5b874b39bda3a6db525d7457
+timeCreated: 1635931050

--- a/MicrowaveGame/Assets/Resources/Scripts/DungeonEntrance/DungeonEntranceBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/DungeonEntrance/DungeonEntranceBehaviour.cs
@@ -1,17 +1,10 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using Scripts.Utilities;
 
 namespace Scripts.DungeonEntrance
 {
-    class DungeonEntranceBehaviour : MonoBehaviour
+	class DungeonEntranceBehaviour : MonoBehaviour
 	{
-		private void Start()
-		{
-			// TODO: temporarily print number of key cards
-			Log.Info($"Keycards: {Persistent.CollectedKeycardCount}");
-		}
-
 		private void OnCollisionEnter2D(Collision2D other)
 		{
 			if (other.gameObject.name != "Player") return;

--- a/MicrowaveGame/Assets/Resources/Scripts/Items/ItemKeyCardBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Items/ItemKeyCardBehaviour.cs
@@ -21,7 +21,7 @@ namespace Scripts.Items
 
 		public override void OnPickupItem(InventorySlotBehaviour inventorySlotBehaviour)
 		{
-			Persistent.CollectedKeycardCount += 1;
+			Persistent.CollectedKeyCardCount += 1;
 			AudioManager.Play(ItemPickup, AudioCategory.Effect, 0.9f);
 			MenuManager.ShowDialogue(_dialogueContentBehaviour.DialogueContent, () =>
 			{

--- a/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelGenerationBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Levels/LevelGenerationBehaviour.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Scripts.Rooms;
 using Scripts.Camera;
+using Scripts.Utilities;
 
 
 namespace Scripts.Levels
@@ -64,9 +65,10 @@ namespace Scripts.Levels
 			if (SceneManager.GetActiveScene().name == "Hub")
 			{
 				// Keep ending door locked until win conditions are met
-				if (Persistent.CollectedKeycardCount < 3)
+				if (Persistent.CollectedKeyCardCount < Persistent.RequiredKeyCardCount)
 				{
 					LockEndingDoor();
+					StartingRoom.transform.Find("EndingDoorChevron").GetComponent<SpriteRenderer>().enabled = false;
 				}
 
 				if (Persistent.FirstTimeInHub) SetupTutorial();

--- a/MicrowaveGame/Assets/Resources/Scripts/Persistent.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Persistent.cs
@@ -3,6 +3,8 @@ namespace Scripts
 	public static class Persistent
 	{
 		public static bool FirstTimeInHub = true;
-		public static int CollectedKeycardCount = 0;
+		
+		public static int CollectedKeyCardCount = 0;
+		public const int RequiredKeyCardCount = 3;
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Utilities/Extensions.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Utilities/Extensions.cs
@@ -77,21 +77,6 @@ namespace Scripts.Utilities
 		public static bool HasComponent<T>(this GameObject gameObject) => gameObject.GetComponent<T>() != null;
 
 		/// <summary>
-		/// Given a name, find the corresponding inactive object.
-		/// </summary>
-		/// <param name="name">The name of the object.</param>
-		/// <returns>Returns the game object that has the given name.</returns>
-		public static GameObject FindInactiveObjectByName(string name)
-		{
-			foreach (var transform in Resources.FindObjectsOfTypeAll<Transform>())
-			{
-				if (transform.hideFlags == HideFlags.None && transform.name == name) return transform.gameObject;
-			}
-
-			return null;
-		}
-
-		/// <summary>
 		/// Convert a Vector2 into a Direction
 		/// </summary>
 		/// <param name="vector2">The Vector2.</param>


### PR DESCRIPTION
Supersedes #177 

This PR implements a card counter that is only visible in the hub scene. Additionally, it adds a chevron to the hub floor that only shows when  the ending door is open.

Note that collecting more cards than the required number to open the ending door is intended (i.e. 4/3 cards).

To test, ensure the card counter only shows in the hub scene. Also ensure that the counter increases once card is collected.