### PR TITLE
Minor fixes

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
@@ -82,13 +82,9 @@ MonoBehaviour:
   DialogueContent:
     Speaker: Merlin
     Sentences:
-    - 'I found it! With this I can restore power to Light City!
-
-      ### Engaging
-      Teleporter ###
-
-      --- Congratulations, you have completed the demo, you''re
-      welcome to play again ---'
+    - This is one of the key cards needed to restore power to Light City!
+    - I should head back to the power station to make sure it's safe.
+    - '### Engaging Teleporter ###'
 --- !u!1001 &1447312555054794971
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemKeyCard.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnProbability: 0
   Name: Key Card
-  Description: This will help restore power to Light City!
+  Description: Helps restore power to Light City!
   ItemPickup: {fileID: 8300000, guid: 60d5fe67f7ae1d048a87eaaa4d9d1b49, type: 3}
 --- !u!114 &8614144819129509974
 MonoBehaviour:

--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemProjectileSize.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemProjectileSize.prefab
@@ -64,10 +64,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpawnProbability: 1
-  Name: ItemProjectileSize
+  Name: Projectile size
   Description: Increases projectile size
   IncreaseValue: 0.5
-  itemDrop: {fileID: 8300000, guid: de9efefb18faa6948be43037f07b07ca, type: 3}
+  PickupItemAudioCip: {fileID: 8300000, guid: 60d5fe67f7ae1d048a87eaaa4d9d1b49, type: 3}
+  DropItemAudioClip: {fileID: 8300000, guid: de9efefb18faa6948be43037f07b07ca, type: 3}
 --- !u!1001 &8036875327095706385
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemSpeedIncrease.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/ItemSpeedIncrease.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnProbability: 1
   Name: Speed Increase
-  Description: Slighty increase movement speed
+  Description: Increases the player's movement speed
   IncreaseValue: 0.075
   ItemDrop: {fileID: 8300000, guid: de9efefb18faa6948be43037f07b07ca, type: 3}
   SpeedUp: {fileID: 8300000, guid: f1b44806f3713b44aa8ccf1b8f0fe034, type: 3}

--- a/MicrowaveGame/Assets/Resources/Prefabs/Items/TutorialItemHealthIncrease.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Items/TutorialItemHealthIncrease.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnProbability: 0
   Name: Health Increase
-  Description: Heals player damage by {0}
+  Description: Heals the player by {0}
   IncreaseValue: 2
   itemDrop: {fileID: 8300000, guid: de9efefb18faa6948be43037f07b07ca, type: 3}
   healthSFX: {fileID: 8300000, guid: 4a38517e9f642094289d793586a90767, type: 3}

--- a/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
@@ -345,6 +345,7 @@ GameObject:
   m_Component:
   - component: {fileID: 136599201}
   - component: {fileID: 136599202}
+  - component: {fileID: 136599203}
   m_Layer: 5
   m_Name: CardCountDisplay
   m_TagString: Untagged
@@ -385,6 +386,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0bf0aff5b874b39bda3a6db525d7457, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &136599203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136599200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79ef6fa20fd045b1a129b63a45eab395, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DialogueContent:
+    Speaker: Merlin
+    Sentences:
+    - Look! The door to the power room is open!
+    - I can now restore power to Light City!
 --- !u!1 &223219233
 GameObject:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Scripts/Items/ItemProjectileSizeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Items/ItemProjectileSizeBehaviour.cs
@@ -14,7 +14,15 @@ namespace Scripts.Items
 
 		private PlayerShootBehaviour _playerShootBehaviour;
 
-		public AudioClip itemDrop;
+		/// <summary>
+		/// The pickup item audio clip.
+		/// </summary>
+		public AudioClip PickupItemAudioCip;
+		
+		/// <summary>
+		/// The drop item audio clip.
+		/// </summary>
+		public AudioClip DropItemAudioClip;
 
 		public override void Start()
 		{
@@ -26,6 +34,7 @@ namespace Scripts.Items
 		{
 			_playerShootBehaviour.ProjectileScale += IncreaseValue;
 			inventorySlotBehaviour.PlayAnimation("InventorySlotBounceLoop");
+			AudioManager.Play(PickupItemAudioCip, AudioCategory.Effect);
 		}
 
 		public override void OnUseItem(InventorySlotBehaviour inventorySlotBehaviour) { }
@@ -36,7 +45,7 @@ namespace Scripts.Items
 		{
 			_playerShootBehaviour.ProjectileScale -= IncreaseValue;
 			inventorySlotBehaviour.PlayAnimation("InventorySlotBounceContract");
-			AudioManager.Play(itemDrop, AudioCategory.Effect, 0.55f);
+			AudioManager.Play(DropItemAudioClip, AudioCategory.Effect, 0.55f);
 
 			return true;
 		}

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuNarrativeBehaviour.cs
@@ -1,4 +1,5 @@
 ﻿using Scripts.Audio;
+using Scripts.Dialogue;
 using UnityEngine;
 using UnityEngine.UI;
 using Scripts.Utilities;
@@ -44,7 +45,14 @@ namespace Scripts.Menus
 			UpdateTexts();
 
 			MenuManager.Init(this);
-			if (!Persistent.FirstTimeInHub) MenuManager.GoInto("MenuPlaying");
+
+			if (!Persistent.FirstTimeInHub)
+			{
+				MenuManager.GoInto("MenuPlaying");
+
+				if (Persistent.CollectedKeyCardCount == Persistent.RequiredKeyCardCount)
+					MenuManager.ShowDialogue(GameObject.Find("CardCountDisplay").GetComponent<DialogueContentBehaviour>().DialogueContent);
+			}
 			
 			AudioManager.Play(HubLoopAudioClip, AudioCategory.Music, 0.4f, true);
 		}


### PR DESCRIPTION
This PR contains some minor fixes, including:

* Adjustments to item descriptions and missing item pickup sound effects (164c3c231d2ec5857f4feaed1481c233298df309).
* Adding a dialgoue for when the player returns to the hub with enough key cards to open the ending door (f8e1a3f106c5b9fbc9129ec14c4bab489ed89f13).

To test, ensure that item descriptions read okay, and that all items have a pickup, and a drop sound effect. Also ensure that the new dialogue only shows when the player has exactly enough cards to open the door. If they have more (i.e. 4/3), it should not show when they return to the hub.