### PR TITLE
Changed the end of game dialogue content

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
@@ -401,8 +401,10 @@ MonoBehaviour:
   DialogueContent:
     Speaker: Merlin
     Sentences:
-    - Look! The door to the power room is open!
-    - I can now restore power to Light City!
+    - Thank goodness, that should be enough keycards to take the load off of the
+      emergency generators.
+    - But my work isn't done. The Lightbulb Gang still has more stolen key cards.
+    - I need to get every last card back to the power grid as soon as possible
 --- !u!1 &223219233
 GameObject:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Hub.unity
@@ -401,10 +401,11 @@ MonoBehaviour:
   DialogueContent:
     Speaker: Merlin
     Sentences:
-    - Thank goodness, that should be enough keycards to take the load off of the
-      emergency generators.
-    - But my work isn't done. The Lightbulb Gang still has more stolen key cards.
-    - I need to get every last card back to the power grid as soon as possible
+    - Thank goodness, that should be enough keycards to get Light City up and running
+      again
+    - I'm sure my job is done, although if the Lightbulbs still have some keycards
+      left...
+    - Running out of charge though...maybe that can come later after some rest
 --- !u!1 &223219233
 GameObject:
   m_ObjectHideFlags: 0

--- a/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomEndGameBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Rooms/RoomEndGameBehaviour.cs
@@ -37,6 +37,7 @@ namespace Scripts.Rooms
 
 			_ending = true;
      		SceneFaderBehaviour.Instance.FadeInto("Menu");
+			//TODO: Play ending cutscene
 		}
 	}
 }


### PR DESCRIPTION
Changes Made
- Altered the dialogue in DialogueContentBehaviour on CardCountDisplay

How to Observe
- Go to Canvas/CardCountDisplay/DialogueContentBehaviour in the Hub scene to see the new dialogue
- Alternatively, collect three keycards in-game to meet the dialogue trigger