### PR TITLE
Game over screen

### DIFF
--- a/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab
@@ -287,12 +287,15 @@ MonoBehaviour:
     m_LineSpacing: 1
   m_Text: 'Took {0} minute(s), {1} second(s)
 
+
     Defeated {2} enemies
+
 
     Dealt
     {3} damage
 
     Took {4} damage
+
 
     Explored {5} of {6} rooms ({7}%)'
 --- !u!1001 &555244664365642073

--- a/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab
@@ -1,0 +1,497 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &555244664582578990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 555244664582578991}
+  - component: {fileID: 555244664582578988}
+  m_Layer: 5
+  m_Name: MenuGameOver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &555244664582578991
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244664582578990}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 555244665439767921}
+  - {fileID: 555244665616195388}
+  - {fileID: 2460516814032486010}
+  - {fileID: 6378986403079971104}
+  - {fileID: 99827522719600741}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &555244664582578988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244664582578990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff9e2c88b0634221bacbe768e53cdddb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &555244665439767920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 555244665439767921}
+  - component: {fileID: 555244665439767927}
+  - component: {fileID: 555244665439767926}
+  m_Layer: 5
+  m_Name: BackgroundLayout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &555244665439767921
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665439767920}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 555244664582578991}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &555244665439767927
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665439767920}
+  m_CullTransparentMesh: 1
+--- !u!114 &555244665439767926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665439767920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &555244665616195391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 555244665616195388}
+  - component: {fileID: 555244665616195330}
+  - component: {fileID: 555244665616195389}
+  m_Layer: 5
+  m_Name: TitleText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &555244665616195388
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665616195391}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 555244664582578991}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 274.99997}
+  m_SizeDelta: {x: 750, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &555244665616195330
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665616195391}
+  m_CullTransparentMesh: 1
+--- !u!114 &555244665616195389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 555244665616195391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 7c6167e879fc69cd79d23cc3ff3103bb, type: 3}
+    m_FontSize: 72
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 72
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Mission Complete
+--- !u!1 &2361111307663319829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2460516814032486010}
+  - component: {fileID: 783530510069027869}
+  - component: {fileID: 8461135584727512773}
+  m_Layer: 5
+  m_Name: StatisticsText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2460516814032486010
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2361111307663319829}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 555244664582578991}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 750, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &783530510069027869
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2361111307663319829}
+  m_CullTransparentMesh: 1
+--- !u!114 &8461135584727512773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2361111307663319829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 7c6167e879fc69cd79d23cc3ff3103bb, type: 3}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Took {0} minute(s), {1} second(s)
+
+    Defeated {2} enemies
+
+    Dealt
+    {3} damage
+
+    Took {4} damage
+
+    Explored {5} of {6} rooms ({7}%)'
+--- !u!1001 &555244664365642073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 555244664582578991}
+    m_Modifications:
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 32.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4490496494141429358, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+      propertyPath: m_Name
+      value: MenuSelectableIndicator
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+--- !u!224 &99827522719600741 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 492590618585047356, guid: 576e97e552371d5fd9e0124f1eaf6fb0, type: 3}
+  m_PrefabInstance: {fileID: 555244664365642073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &555244665959231516
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 555244664582578991}
+    m_Modifications:
+    - target: {fileID: 4821173537813569984, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932733, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_Name
+      value: DoneButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 555244664582578988}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnDoneButtonPressed
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Scripts.Menus.MenuGameOverBehaviour, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569658975932735, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6859569659326029379, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+      propertyPath: m_Text
+      value: Done
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+--- !u!224 &6378986403079971104 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6859569658975932732, guid: b463d0ce4ce4cc59db36125c35cf0a01, type: 3}
+  m_PrefabInstance: {fileID: 555244665959231516}
+  m_PrefabAsset: {fileID: 0}

--- a/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab.meta
+++ b/MicrowaveGame/Assets/Resources/Prefabs/Menus/MenuGameOver.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2e6e171ec92a07f8919cc325a55f433
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
+++ b/MicrowaveGame/Assets/Resources/Scenes/Gameplay.unity
@@ -148,7 +148,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5794048396616728324, guid: 144c13c09b1619746941aa827c09675c, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5794048396616728324, guid: 144c13c09b1619746941aa827c09675c, type: 3}
       propertyPath: m_AnchorMax.x
@@ -250,7 +250,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
       propertyPath: m_AnchorMax.x
@@ -334,6 +334,11 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6580432558772047829, guid: 833e5478a5f7093468a4d5ec2a5e8e53, type: 3}
   m_PrefabInstance: {fileID: 77326879}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &380342541 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+  m_PrefabInstance: {fileID: 555244664874840610}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &380900815
 PrefabInstance:
@@ -441,6 +446,49 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7333766769061139434, guid: f0d89f81af97b914da3eeac9eec64f20, type: 3}
   m_PrefabInstance: {fileID: 380900815}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &547589993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 547589995}
+  - component: {fileID: 547589994}
+  m_Layer: 0
+  m_Name: StatisticsTracker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &547589994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547589993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7866ad8dcdc4f2a9a1d5f0c1a874a8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &547589995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547589993}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &547911200
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1090,11 +1138,12 @@ RectTransform:
   - {fileID: 1013965761}
   - {fileID: 1160041348}
   - {fileID: 2146856306}
+  - {fileID: 380342541}
   - {fileID: 2074115366}
   - {fileID: 51205459}
   - {fileID: 77326880}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1173,7 +1222,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1782651768
 PrefabInstance:
@@ -1343,7 +1392,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4772921886234655895, guid: 43dde89c4b7a90540a71d2a9c371a685, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4772921886234655895, guid: 43dde89c4b7a90540a71d2a9c371a685, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1570,3 +1619,104 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 1136289162091159327, guid: a35466c089d585383ba0857f4864e756, type: 3}
   m_PrefabInstance: {fileID: 2146856305}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &555244664874840610
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1303808621}
+    m_Modifications:
+    - target: {fileID: 555244664582578990, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_Name
+      value: MenuGameOver
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578990, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 555244664582578991, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b2e6e171ec92a07f8919cc325a55f433, type: 3}

--- a/MicrowaveGame/Assets/Resources/Scripts/Items/ItemKeyCardBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Items/ItemKeyCardBehaviour.cs
@@ -3,7 +3,6 @@ using Scripts.Dialogue;
 using Scripts.Menus;
 using Scripts.Audio;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Scripts.Items
 {
@@ -16,17 +15,16 @@ namespace Scripts.Items
 		public override void Start()
 		{
 			base.Start();
- 			_dialogueContentBehaviour = GetComponent<DialogueContentBehaviour>();
+			_dialogueContentBehaviour = GetComponent<DialogueContentBehaviour>();
 		}
 
 		public override void OnPickupItem(InventorySlotBehaviour inventorySlotBehaviour)
 		{
 			Persistent.CollectedKeyCardCount += 1;
 			AudioManager.Play(ItemPickup, AudioCategory.Effect, 0.9f);
-			MenuManager.ShowDialogue(_dialogueContentBehaviour.DialogueContent, () =>
-			{
-				SceneManager.LoadScene("Hub");
-			});
+
+			MenuManager.ShowDialogue(_dialogueContentBehaviour.DialogueContent,
+				() => { MenuManager.GoInto("MenuGameOver"); });
 		}
 
 		public override void OnUseItem(InventorySlotBehaviour inventorySlotBehaviour) { }

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using Scripts.Rooms;
 using Scripts.Scenes;
+using Scripts.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,9 @@ namespace Scripts.Menus
 	public class MenuGameOverBehaviour : MenuBehaviour
 	{
 		private Text _statisticsText;
+
+		private const float StatisticsLerpTimeSeconds = 4.0f;
+		private Lerped<string> _statisticsTextContent = new Lerped<string>(string.Empty, StatisticsLerpTimeSeconds, Interpolate, true);
 
 		/// <summary>
 		/// Sets the current scene to the "Hub" scene.
@@ -39,10 +43,23 @@ namespace Scripts.Menus
 				Explored {5} of {6} rooms ({7}%)
 			 */
 
-			_statisticsText.text = string.Format(_statisticsText.text, timeTaken.Minutes, timeTaken.Seconds,
+			_statisticsTextContent.Value = string.Format(_statisticsText.text, timeTaken.Minutes, timeTaken.Seconds,
 				statisticsTrackerBehaviour.EnemiesDefeated, statisticsTrackerBehaviour.DamageDealt,
 				statisticsTrackerBehaviour.DamageTaken, totalRooms,
 				statisticsTrackerBehaviour.RoomsExplored, roomsExploredPercentage);
+
+			_statisticsText.text = string.Empty;
+		}
+
+		private void Update()
+		{
+			_statisticsText.text = _statisticsTextContent.Value;
+		}
+
+		private static string Interpolate(string _, string line, float interpolation)
+		{
+			if (string.IsNullOrWhiteSpace(line)) return string.Empty;
+			return line.Substring(0, (int) (line.Length * interpolation));
 		}
 	}
 }

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
@@ -1,0 +1,48 @@
+using System;
+using Scripts.Rooms;
+using Scripts.Scenes;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Scripts.Menus
+{
+	public class MenuGameOverBehaviour : MenuBehaviour
+	{
+		private Text _statisticsText;
+
+		/// <summary>
+		/// Sets the current scene to the "Hub" scene.
+		/// Called when the "Done" button is pressed.
+		/// </summary>
+		public void OnDoneButtonPressed() => SceneFaderBehaviour.Instance.FadeInto("Hub");
+
+		private void OnEnable()
+		{
+			StatisticsTrackerBehaviour statisticsTrackerBehaviour =
+				GameObject.Find("StatisticsTracker").GetComponent<StatisticsTrackerBehaviour>();
+
+			_statisticsText = transform.Find("StatisticsText").GetComponent<Text>();
+
+			TimeSpan timeTaken =
+				TimeSpan.FromMilliseconds(Time.time * 1000 - statisticsTrackerBehaviour.StartTime * 1000);
+
+			int totalRooms = FindObjectsOfType<RoomConnectionBehaviour>(true).Length;
+
+			float roomsExploredPercentage =
+				(float) Math.Round(statisticsTrackerBehaviour.RoomsExplored / (float) totalRooms * 100, 2);
+
+			/*
+				Took {0} minutes, {1} seconds
+				Defeated {2} enemies
+				Dealt {3} damage
+				Took {4} damage
+				Explored {5} of {6} rooms ({7}%)
+			 */
+
+			_statisticsText.text = string.Format(_statisticsText.text, timeTaken.Minutes, timeTaken.Seconds,
+				statisticsTrackerBehaviour.EnemiesDefeated, statisticsTrackerBehaviour.DamageDealt,
+				statisticsTrackerBehaviour.DamageTaken, totalRooms,
+				statisticsTrackerBehaviour.RoomsExplored, roomsExploredPercentage);
+		}
+	}
+}

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs
@@ -45,8 +45,8 @@ namespace Scripts.Menus
 
 			_statisticsTextContent.Value = string.Format(_statisticsText.text, timeTaken.Minutes, timeTaken.Seconds,
 				statisticsTrackerBehaviour.EnemiesDefeated, statisticsTrackerBehaviour.DamageDealt,
-				statisticsTrackerBehaviour.DamageTaken, totalRooms,
-				statisticsTrackerBehaviour.RoomsExplored, roomsExploredPercentage);
+				statisticsTrackerBehaviour.DamageTaken, statisticsTrackerBehaviour.RoomsExplored, totalRooms,
+				roomsExploredPercentage);
 
 			_statisticsText.text = string.Empty;
 		}

--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs.meta
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuGameOverBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ff9e2c88b0634221bacbe768e53cdddb
+timeCreated: 1636018658

--- a/MicrowaveGame/Assets/Resources/Scripts/StatisticsTrackerBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/StatisticsTrackerBehaviour.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Scripts.Events;
+using Scripts.Levels;
+using Scripts.Utilities;
+using UnityEngine;
+
+namespace Scripts
+{
+	public class StatisticsTrackerBehaviour : MonoBehaviour
+	{
+		public float StartTime { get; private set; }
+		public int EnemiesDefeated { get; private set; }
+		public int DamageDealt { get; private set; }
+		public int DamageTaken { get; private set; }
+		public int RoomsExplored => _visitedRooms.Count;
+
+		private readonly HashSet<int> _visitedRooms = new HashSet<int>();
+
+		private EventId<HealthChangedEventArgs> _healthChangedEventId;
+		private EventId<RoomTraversedEventArgs> _roomTraversedEventId;
+
+		private void Start()
+		{
+			_healthChangedEventId = EventManager.Register<HealthChangedEventArgs>(OnHealthChanged);
+			_roomTraversedEventId = EventManager.Register<RoomTraversedEventArgs>(OnRoomTraversed);
+
+			StartTime = Time.time;
+		}
+
+		private void OnDestroy()
+		{
+			EventManager.Unregister(_healthChangedEventId);
+			EventManager.Unregister(_roomTraversedEventId);
+		}
+
+		private void OnHealthChanged(HealthChangedEventArgs eventArgs)
+		{
+			if (eventArgs.GameObject.name == "Player" && eventArgs.NewValue < eventArgs.OldValue)
+				DamageTaken += eventArgs.OldValue - eventArgs.NewValue;
+
+			TagBehaviour tagBehaviour = eventArgs.GameObject.GetComponent<TagBehaviour>();
+
+			if (tagBehaviour != null && tagBehaviour.HasTag("Enemy") && eventArgs.NewValue < eventArgs.OldValue)
+			{
+				DamageDealt += eventArgs.OldValue - eventArgs.NewValue;
+				if (eventArgs.NewValue <= 0) EnemiesDefeated++;
+			}
+		}
+
+		private void OnRoomTraversed(RoomTraversedEventArgs eventArgs)
+		{
+			int id = eventArgs.CurrentRoom.gameObject.GetInstanceID();
+			_visitedRooms.Add(id);
+		}
+	}
+}

--- a/MicrowaveGame/Assets/Resources/Scripts/StatisticsTrackerBehaviour.cs.meta
+++ b/MicrowaveGame/Assets/Resources/Scripts/StatisticsTrackerBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f7866ad8dcdc4f2a9a1d5f0c1a874a8a
+timeCreated: 1636020101

--- a/MicrowaveGame/ProjectSettings/ProjectSettings.asset
+++ b/MicrowaveGame/ProjectSettings/ProjectSettings.asset
@@ -140,6 +140,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
This PR adds the game over screen that shows when you collect a key card, showing statistics like time taken, rooms explored percentage, etc.

![2021-11-04-222407_2558x1440_scrot](https://user-images.githubusercontent.com/54171299/140305527-44eef9dc-5614-46b7-b363-580d0dd29ed2.png)

To test, collect a key card and validate the information is correct.