### PR TITLE
The opening cutscene now only plays once

### DIFF
--- a/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuMainBehaviour.cs
+++ b/MicrowaveGame/Assets/Resources/Scripts/Menus/MenuMainBehaviour.cs
@@ -37,7 +37,17 @@ namespace Scripts.Menus
 		/// Sets the current scene to the "OpeningCutscene" scene.
 		/// Called when the "Start" button is pressed.
 		/// </summary>
-		public void OnStartButtonPressed() => SceneFaderBehaviour.Instance.FadeInto("OpeningCutscene"); //OpeningCutScene then Hub
+		public void OnStartButtonPressed() 
+		{
+			if (Persistent.FirstTimeInHub)
+			{
+				SceneFaderBehaviour.Instance.FadeInto("OpeningCutscene");
+			}
+			else
+			{
+				SceneFaderBehaviour.Instance.FadeInto("Hub");
+			}
+		}
 
 		/// <summary>
 		/// Sets the current menu to the "Settings" menu.


### PR DESCRIPTION
## Description

Currently the opening cut-scene plays every time you press play, so if you play, return to main menu and play again it will replay the cut-scene. This PR changes it so it only plays the first time the user hits play (per game launch).

## How to test

Ensure that returning to main menu and pressing play again takes you straight to the hub.